### PR TITLE
Custom JIRA base URL, exception with invalid PEM

### DIFF
--- a/src/Provider.php
+++ b/src/Provider.php
@@ -8,7 +8,7 @@ use Laravel\Socialite\One\User;
 class Provider extends AbstractProvider
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function user()
     {

--- a/src/RsaSha1Signature.php
+++ b/src/RsaSha1Signature.php
@@ -9,7 +9,7 @@ use Guzzle\Http\Url;
 class RsaSha1Signature extends Signature implements SignatureInterface
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function method()
     {
@@ -17,7 +17,7 @@ class RsaSha1Signature extends Signature implements SignatureInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function sign($uri, array $parameters = [], $method = 'POST')
     {
@@ -28,7 +28,7 @@ class RsaSha1Signature extends Signature implements SignatureInterface
         $certificate = openssl_pkey_get_private('file://'.storage_path().'/app/keys/jira.pem');
 
         if ($certificate === false) {
-            throw new \Exception("Cannot get private key.");
+            throw new \Exception('Cannot get private key.');
         }
 
         // Pull the private key ID from the certificate

--- a/src/RsaSha1Signature.php
+++ b/src/RsaSha1Signature.php
@@ -27,6 +27,10 @@ class RsaSha1Signature extends Signature implements SignatureInterface
         // Fetch the private key cert based on the request
         $certificate = openssl_pkey_get_private('file://'.storage_path().'/app/keys/jira.pem');
 
+        if ($certificate === false) {
+            throw new \Exception("Cannot get private key.");
+        }
+
         // Pull the private key ID from the certificate
         $privatekeyid = openssl_get_privatekey($certificate);
 

--- a/src/RsaSha1Signature.php
+++ b/src/RsaSha1Signature.php
@@ -17,15 +17,22 @@ class RsaSha1Signature extends Signature implements SignatureInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Sign the given request for the client.
+     *
+     * @param string $uri
+     * @param array  $parameters
+     * @param string $method
+     * @param string $certPath
+     *
+     * @return string
      */
-    public function sign($uri, array $parameters = [], $method = 'POST')
+    public function sign($uri, array $parameters = [], $method = 'POST', $certPath = '')
     {
         $url = $this->createUrl($uri);
         $baseString = $this->baseString($url, $method, $parameters);
 
         // Fetch the private key cert based on the request
-        $certificate = openssl_pkey_get_private('file://'.storage_path().'/app/keys/jira.pem');
+        $certificate = openssl_pkey_get_private("file://$certPath");
 
         if ($certificate === false) {
             throw new \Exception('Cannot get private key.');

--- a/src/Server.php
+++ b/src/Server.php
@@ -38,7 +38,7 @@ class Server extends BaseServer
     }
 
     /**
-     * Get JIRA base URL
+     * Get JIRA base URL.
      *
      * @return string
      */
@@ -66,7 +66,7 @@ class Server extends BaseServer
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function urlTemporaryCredentials()
     {
@@ -75,7 +75,7 @@ class Server extends BaseServer
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function urlAuthorization()
     {
@@ -83,7 +83,7 @@ class Server extends BaseServer
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function urlTokenCredentials()
     {
@@ -91,7 +91,7 @@ class Server extends BaseServer
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function urlUserDetails()
     {
@@ -99,7 +99,7 @@ class Server extends BaseServer
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function userDetails($data, TokenCredentials $tokenCredentials)
     {
@@ -107,7 +107,7 @@ class Server extends BaseServer
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function userUid($data, TokenCredentials $tokenCredentials)
     {
@@ -115,7 +115,7 @@ class Server extends BaseServer
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function userScreenName($data, TokenCredentials $tokenCredentials)
     {
@@ -123,7 +123,7 @@ class Server extends BaseServer
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function userEmail($data, TokenCredentials $tokenCredentials)
     {

--- a/src/Server.php
+++ b/src/Server.php
@@ -12,6 +12,7 @@ class Server extends BaseServer
     const JIRA_BASE_URL = 'http://example.jira.com';
 
     private $jiraBaseUrl;
+    private $jiraCertPath;
 
     /**
      * Create a new server instance.
@@ -26,6 +27,7 @@ class Server extends BaseServer
         // Pass through an array or client credentials, we don't care
         if (is_array($clientCredentials)) {
             $this->jiraBaseUrl = isset($clientCredentials['base_url']) ? $clientCredentials['base_url'] : null;
+            $this->jiraCertPath = isset($clientCredentials['cert']) ? $clientCredentials['cert'] : storage_path().'/app/keys/jira.pem';
             $clientCredentials = $this->createClientCredentials($clientCredentials);
         } elseif (!$clientCredentials instanceof ClientCredentialsInterface) {
             throw new \InvalidArgumentException('Client credentials must be an array or valid object.');
@@ -60,7 +62,7 @@ class Server extends BaseServer
         $parameters = $this->baseProtocolParameters();
 
         // without 'oauth_callback'
-        $parameters['oauth_signature'] = $this->signature->sign($uri, $parameters, 'POST');
+        $parameters['oauth_signature'] = $this->signature->sign($uri, $parameters, 'POST', $this->$jiraCertPath);
 
         return $this->normalizeProtocolParameters($parameters);
     }

--- a/src/Server.php
+++ b/src/Server.php
@@ -11,6 +11,8 @@ class Server extends BaseServer
 {
     const JIRA_BASE_URL = 'http://example.jira.com';
 
+    private $jiraBaseUrl;
+
     /**
      * Create a new server instance.
      *
@@ -23,6 +25,7 @@ class Server extends BaseServer
     {
         // Pass through an array or client credentials, we don't care
         if (is_array($clientCredentials)) {
+            $this->jiraBaseUrl = isset($clientCredentials['base_url']) ? $clientCredentials['base_url'] : null;
             $clientCredentials = $this->createClientCredentials($clientCredentials);
         } elseif (!$clientCredentials instanceof ClientCredentialsInterface) {
             throw new \InvalidArgumentException('Client credentials must be an array or valid object.');
@@ -32,6 +35,16 @@ class Server extends BaseServer
 
         // !! RsaSha1Signature for Jira
         $this->signature = $signature ?: new RsaSha1Signature($clientCredentials);
+    }
+
+    /**
+     * Get JIRA base URL
+     *
+     * @return string
+     */
+    public function getJiraBaseUrl()
+    {
+        return empty($this->jiraBaseUrl) ? self::JIRA_BASE_URL : $this->jiraBaseUrl;
     }
 
     /**


### PR DESCRIPTION
When setting up this JIRA Socialite provider it took me a while to figure out where to put the PEM file. This should make it a bit more obvious.

I also think there should be an easy way to configure the JIRA base URL. I'm not sure if this is the best way to go about this, but I thought I would propose this solution. Ideally, this config should be in the same place as the other config in `config/services.php`:

```
return [
    'jira' => [
        'base_url' => env('JIRA_BASE_URL'),
        'client_id' => env('JIRA_KEY'),
        'client_secret' => env('JIRA_SECRET'),
        'redirect' => env('JIRA_REDIRECT_URI'),
    ],
];
```

For this to work, however, an update is needed to Laravel Socialite. The required update is in [this pull request]().
